### PR TITLE
Change qty from str to int

### DIFF
--- a/algo.py
+++ b/algo.py
@@ -72,7 +72,7 @@ def find_stop(current_value, minute_history, now):
 
 def run(tickers, market_open_dt, market_close_dt):
     # Establish streaming connection
-    conn = tradeapi.StreamConn(key_id=api_key_id, secret_key=api_secret)
+    conn = tradeapi.StreamConn(base_url=base_url, key_id=api_key_id, secret_key=api_secret)
 
     # Update initial state with information from tickers
     volume_today = {}

--- a/algo.py
+++ b/algo.py
@@ -123,7 +123,7 @@ def run(tickers, market_open_dt, market_close_dt):
         if last_order is not None:
             event = data.event
             if event == 'partial_fill':
-                qty = data.order['filled_qty']
+                qty = int(data.order['filled_qty'])
                 if data.order['side'] == 'sell':
                     qty = qty * -1
                 positions[symbol] = (
@@ -133,7 +133,7 @@ def run(tickers, market_open_dt, market_close_dt):
                 positions[symbol] += qty
                 open_orders[symbol] = data.order
             elif event == 'fill':
-                qty = data.order['filled_qty']
+                qty = int(data.order['filled_qty'])
                 if data.order['side'] == 'sell':
                     qty = qty * -1
                 positions[symbol] = (


### PR DESCRIPTION
This should resolve the below error.

File “algo.py”, line 143, in handle_trade_update
   positions[symbol] += qty
TypeError: unsupported operand type(s) for +=: ‘int’ and ‘str’