### PR TITLE
from ta.trend import macd

### DIFF
--- a/algo.py
+++ b/algo.py
@@ -1,7 +1,7 @@
 import alpaca_trade_api as tradeapi
 import requests
 import time
-from ta import macd
+from ta.trend import macd
 import numpy as np
 from datetime import datetime, timedelta
 from pytz import timezone


### PR DESCRIPTION
the macd trend indicator has been moved to ta.trend class
from ta.trend import macd

Source: https://gitmemory.com/issue/alpacahq/Momentum-Trading-Example/13/608196425